### PR TITLE
Add text-to-speech tool

### DIFF
--- a/src/common/ollama_client.py
+++ b/src/common/ollama_client.py
@@ -23,3 +23,11 @@ class OllamaClient:
                 data = json.loads(line)
                 text += data.get("response", "")
         return text
+
+    def tts(self, text: str, **params: Any) -> bytes:
+        """Convert text to speech using the local model."""
+        payload: Dict[str, Any] = {"model": self.model, "prompt": text}
+        payload.update(params)
+        response = requests.post(f"{self.host}/api/tts", json=payload, timeout=60)
+        response.raise_for_status()
+        return response.content

--- a/src/mcp_tool/__init__.py
+++ b/src/mcp_tool/__init__.py
@@ -1,0 +1,4 @@
+from .tool import ExampleTool
+from .tts_tool import TTSTool
+
+__all__ = ["ExampleTool", "TTSTool"]

--- a/src/mcp_tool/tts_tool.py
+++ b/src/mcp_tool/tts_tool.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Literal
+
+import requests
+
+from common.ollama_client import OllamaClient
+
+
+class TTSTool:
+    """Tool for converting text to speech audio bytes."""
+
+    def __init__(
+        self,
+        backend: Literal["api", "ollama"] = "api",
+        api_url: str | None = None,
+        model: str = "tts",
+        host: str = "http://localhost:11434",
+    ) -> None:
+        self.backend = backend
+        self.api_url = api_url or "https://api.example.com/tts"
+        self.client: OllamaClient | None = None
+        if backend == "ollama":
+            self.client = OllamaClient(model=model, host=host)
+
+    def run(self, text: str) -> bytes:
+        """Generate speech audio from the provided text."""
+        if self.backend == "ollama":
+            assert self.client is not None
+            return self.client.tts(text)
+        resp = requests.post(self.api_url, json={"text": text}, timeout=60)
+        resp.raise_for_status()
+        return resp.content

--- a/src/mcp_tool/tts_tool.py
+++ b/src/mcp_tool/tts_tool.py
@@ -26,7 +26,8 @@ class TTSTool:
     def run(self, text: str) -> bytes:
         """Generate speech audio from the provided text."""
         if self.backend == "ollama":
-            assert self.client is not None
+            if self.client is None:
+                raise RuntimeError("Ollama backend is not configured")
             return self.client.tts(text)
         resp = requests.post(self.api_url, json={"text": text}, timeout=60)
         resp.raise_for_status()

--- a/tests/test_tts_tool.py
+++ b/tests/test_tts_tool.py
@@ -1,0 +1,27 @@
+from unittest.mock import Mock, patch
+
+from mcp_tool.tts_tool import TTSTool
+
+
+def _fake_response(content: bytes) -> Mock:
+    resp = Mock()
+    resp.content = content
+    resp.raise_for_status = Mock()
+    return resp
+
+
+def test_api_backend() -> None:
+    tool = TTSTool(backend="api", api_url="http://example.com/tts")
+    with patch("requests.post", return_value=_fake_response(b"api")) as post:
+        audio = tool.run("Hello")
+    assert audio == b"api"
+    post.assert_called_once()
+
+
+def test_ollama_backend() -> None:
+    tool = TTSTool(backend="ollama", model="voice")
+    with patch("requests.post", return_value=_fake_response(b"ollama")) as post:
+        audio = tool.run("Hi")
+    assert audio == b"ollama"
+    post.assert_called_once()
+    assert post.call_args[0][0].endswith("/api/tts")

--- a/tests/test_tts_tool.py
+++ b/tests/test_tts_tool.py
@@ -12,7 +12,7 @@ def _fake_response(content: bytes) -> Mock:
 
 def test_api_backend() -> None:
     tool = TTSTool(backend="api", api_url="http://example.com/tts")
-    with patch("requests.post", return_value=_fake_response(b"api")) as post:
+    with patch("mcp_tool.tts_tool.requests.post", return_value=_fake_response(b"api")) as post:
         audio = tool.run("Hello")
     assert audio == b"api"
     post.assert_called_once()
@@ -20,7 +20,9 @@ def test_api_backend() -> None:
 
 def test_ollama_backend() -> None:
     tool = TTSTool(backend="ollama", model="voice")
-    with patch("requests.post", return_value=_fake_response(b"ollama")) as post:
+    with patch(
+        "common.ollama_client.requests.post", return_value=_fake_response(b"ollama")
+    ) as post:
         audio = tool.run("Hi")
     assert audio == b"ollama"
     post.assert_called_once()


### PR DESCRIPTION
## Summary
- extend Ollama client with text-to-speech capability
- implement TTSTool supporting API or local Ollama backends
- cover TTSTool with unit tests

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c37fbd4f788332a8c061f9860db5fc